### PR TITLE
Force TLS 1.2 on web downloads

### DIFF
--- a/installer.ps1
+++ b/installer.ps1
@@ -93,6 +93,9 @@ if (!(Test-Path .\temp)){
 Start-Sleep -s 1
 # downloading things... TODO: verify downloads and add alternate mirrors
 
+# before we start, set PS to allow any type of TLS, older versions only allow 1.0 by default
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 # download 7zip cli zip
 if (!(Test-Path .\temp\7zip\)){
     echo "Downloading 7-Zip CLI"


### PR DESCRIPTION
Older versions of PowerShell don't allow anything else but TLS 1.0 by default, causing downloads to silently fail as most web servers no longer support it