### PR TITLE
exit after elevating

### DIFF
--- a/installer.ps1
+++ b/installer.ps1
@@ -3,6 +3,7 @@ if (-Not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
  if ([int](Get-CimInstance -Class Win32_OperatingSystem | Select-Object -ExpandProperty BuildNumber) -ge 6000) {
   $CommandLine = "-File `"" + $MyInvocation.MyCommand.Path + "`" " + $MyInvocation.UnboundArguments
   Start-Process -FilePath PowerShell.exe -Verb Runas -ArgumentList $CommandLine
+  Exit
  }
 }
 echo ""


### PR DESCRIPTION
prevents bug where script would carry on in non-elevated context